### PR TITLE
Exclude Globs

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -24,6 +24,15 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/1144075?v=3",
       "profile": "https://github.com/cloud-walker",
       "contributions": []
+    },
+    {
+      "login": "robwise",
+      "name": "Rob Wise",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6173488?v=3",
+      "profile": "https://robwise.github.io",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Atom package to format your JavaScript using Prettier and ESLint (with `eslint -
 [![downloads][downloads-badge]][package]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -58,8 +58,8 @@ This repository is a copy + modification of [`prettier-atom`](https://github.com
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/prettier-eslint-atom/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/prettier-eslint-atom/commits?author=kentcdodds) 🚇 | [<img src="https://avatars.githubusercontent.com/u/1144075?v=3" width="100px;"/><br /><sub>Luca Barone</sub>](https://github.com/cloud-walker)<br /> |
-| :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/prettier-eslint-atom/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/prettier-eslint-atom/commits?author=kentcdodds) 🚇 | [<img src="https://avatars.githubusercontent.com/u/1144075?v=3" width="100px;"/><br /><sub>Luca Barone</sub>](https://github.com/cloud-walker)<br /> | [<img src="https://avatars.githubusercontent.com/u/6173488?v=3" width="100px;"/><br /><sub>Rob Wise</sub>](https://robwise.github.io)<br />[💻](https://github.com/kentcdodds/prettier-eslint-atom/commits?author=robwise) |
+| :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "find-root": "^1.0.0",
     "loophole": "^1.1.0",
+    "minimatch": "^3.0.3",
     "prettier-eslint": "^2.3.3"
   },
   "devDependencies": {
@@ -91,6 +92,13 @@
         "type": "string"
       },
       "order": 2
+    },
+    "excludedGlobs": {
+      "title": "Exclude (list of globs)",
+      "description": "A list of file globs to exclude from formatting on save (takes precedence over scopes). Use commas to seperate each glob",
+      "type": "array",
+      "default": [],
+      "order": 3
     }
   },
   "repository": {


### PR DESCRIPTION
Some developers may wish to exclude certain file types or even entire projects from being formatted.
These developers can add the appropriate file globs to the **Exclude (list of globs)** setting with
each glob separated by a comma. Excluded globs take precedence over scopes, so even if a file is in
scope, it will still not be formatted on save if the file matches an exclusion glob. These changes
are for `formatOnSave` only. They have no effect when manually invoking. Globs are matched using the
minimatch library.